### PR TITLE
Fixes ContentElementWizard.txt not found warnings

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,4 +23,4 @@ $iconRegistry->registerIcon(
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info'][$_EXTKEY . '_registration'][$_EXTKEY] =
     \Sup7even\Mailchimp\Hooks\Backend\PageLayoutViewHook::class . '->getExtensionSummary';
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:mailchimp/Configuration/TSconfig/ContentElementWizard.txt">');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:mailchimp/Configuration/TSconfig/ContentElementWizard.typoscript">');


### PR DESCRIPTION
`addPageTSConfig()` in `ext_localconf.php` references `ContentElementWizard.txt` instead of `ContentElementWizard.typoscript` which results in `File "EXT:mailchimp/Configuration/TSconfig/ContentElementWizard.txt" was not found` log messages.