### PR TITLE
Fixes path to extension icon

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,7 +16,7 @@ $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\
 $iconRegistry->registerIcon(
     'ext-mailchimp-wizard-icon',
     \TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider::class,
-    ['source' => 'EXT:mailchimp/ext_icon.png']
+    ['source' => 'EXT:mailchimp/Resources/Public/Icons/Extension.png']
 );
 
 // Page module hook


### PR DESCRIPTION
The path to the extension icon is wrong. This small fix brings the Mailchimp icon back.
<img width="477" alt="Bildschirmfoto 2021-02-07 um 23 30 52" src="https://user-images.githubusercontent.com/15139/107158645-d92e6880-698b-11eb-81b4-2c7fb31787c1.png">

Tested under Typo3 10.4.12