### PR TITLE
Process mailchimp forms based on class name instead of id

### DIFF
--- a/Resources/Private/Templates/Form/Index.html
+++ b/Resources/Private/Templates/Form/Index.html
@@ -5,13 +5,12 @@
 <f:layout name="General"/>
 
 <f:section name="content">
-    <f:form object="{form}" action="response" name="form" id="mailchimp-form" class="form-horizontal"
+    <f:form object="{form}" action="response" name="form" class="form-horizontal mailchimp-form"
             data="{url:'{f:render(section:\'formUrl\') -> f:spaceless() -> f:format.htmlentitiesDecode()}'}">
         <f:form.validationResults>
             <f:if condition="{validationResults.flattenedErrors}">
                 <ul class="errors">
                     <f:for each="{validationResults.flattenedErrors}" as="errors" key="propertyPath">
-
                         <f:for each="{errors}" as="error">
                             <li>
                                 <f:translate key="error.{propertyPath}.{error.code}"
@@ -66,7 +65,7 @@
         <mc:footerData>
             <script type="text/javascript" src="{f:uri.resource(path:'JavaScript/mailchimp.js')}"></script>
         </mc:footerData>
-        <div id="mailchimp-ajax-response"></div>
+        <div class="mailchimp-ajax-response"></div>
     </f:form>
 </f:section>
 

--- a/Resources/Public/JavaScript/mailchimp.js
+++ b/Resources/Public/JavaScript/mailchimp.js
@@ -1,22 +1,27 @@
+$(function () {
+    let $extMailchimpForms = $('form.mailchimp-form');
 
-$(document).on('submit', '#mailchimp-form', function (e) {
-    'use strict';
+    if ($extMailchimpForms.length) {
 
-    let $this = $(this),
-        url = $this.data('url');
+        $extMailchimpForms.on('submit', function (e) {
 
-    if (url) {
-        e.preventDefault();
+            let $this = $(this),
+                url = $this.data('url');
 
-        $.ajax({
-            type: 'POST',
-            url: url,
-            data: $this.serialize(),
-            dataType: 'html',
-            encode: false
-        })
-            .done(function (data) {
-                $('#mailchimp-ajax-response').html(data);
-            });
+            if (url) {
+                e.preventDefault();
+
+                $.ajax({
+                    type: 'POST',
+                    url: url,
+                    data: $this.serialize(),
+                    dataType: 'html',
+                    encode: false
+                })
+                    .done(function (data) {
+                        $('.mailchimp-ajax-response', $this).html(data);
+                    });
+            }
+        });
     }
 });


### PR DESCRIPTION
I had the problem to use the Mailchimp extension twice on a page (constant in the footer and inside content). It always resulted in DOM errors – because id="mailchimp-form" isn't unique in this case.

Because I did not find a simple solution to load another template (Templates/Form/Index.html) to just use a completely different structure I have refactored the JavaScript.

Bit off-topic:
Would be great to have an option to select another template or just have access to the outer tt_content values. I thought to use a custom tt_content.layout value as condition but it's not available when the mailchimp form is rendered.